### PR TITLE
Handle null in TextUtil.parseString

### DIFF
--- a/src/main/java/com/humbrain/plugincommons/utils/TextUtil.java
+++ b/src/main/java/com/humbrain/plugincommons/utils/TextUtil.java
@@ -22,7 +22,9 @@ public class TextUtil {
     }
 
     public static String parseString(String text) {
-        return translateHexColorCodes(text).replace('&', '§');
+        text = translateHexColorCodes(text);
+        if (text == null) return ""; // ✅ sécurité NPE
+        return text.replace('&', '§');
     }
 
     public static List<String> parseListString(List<String> text) {


### PR DESCRIPTION
## Summary
- avoid potential NPE when parsing colored strings

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_688db275caec832692e5020ca6bba03d